### PR TITLE
ci: update deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/e2e-environment.yml
+++ b/.github/workflows/e2e-environment.yml
@@ -108,17 +108,17 @@ jobs:
 
       ## SETUP
       - name: 🛎 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: 🚧 Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
       - name: 🚀 Dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |
@@ -206,7 +206,7 @@ jobs:
 
     steps:
       - name: 🛎 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
@@ -216,7 +216,7 @@ jobs:
           node-version: "node"
 
       - name: 🚀 Dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |
@@ -291,17 +291,17 @@ jobs:
 
     steps:
       - name: 🛎 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: 🚧 Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
       - name: 🚀 Dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -100,7 +100,7 @@ jobs:
 
       ## SETUP
       - name: 🛎 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
@@ -110,7 +110,7 @@ jobs:
           node-version: "node"
 
       - name: 🚀 Dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |
@@ -195,17 +195,17 @@ jobs:
 
     steps:
       - name: 🛎 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: 🚧 Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
       - name: 🚀 Dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |
@@ -278,17 +278,17 @@ jobs:
 
     steps:
       - name: 🛎 Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: 🚧 Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
       - name: 🚀 Dependencies cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Updates all deprecated GitHub Actions across the three shared reusable workflows to v4. GitHub has already shut down `actions/cache@v2` and `actions/upload-artifact@v2`, and v3 is next. Any project consuming these workflows will fail CI once v3 is fully deprecated.

## Changes

| Action | Old | New | Files |
|---|---|---|---|
| `actions/checkout` | v3 | v4 | e2e.yml, e2e-environment.yml, lint.yml |
| `actions/setup-node` | v3 | v4 | e2e.yml, e2e-environment.yml |
| `actions/cache` | v3 | v4 | e2e.yml, e2e-environment.yml |

Instances already at v4 (e.g. `setup-node@v4` in the `install-and-cache-dependencies` job) were left untouched.

## Out of scope (flagged for future)

- Cypress container image `cypress/browsers:node16.18.0-chrome107-ff106-edge` uses EOL Node 16
- `actions/setup-node` with `node-version: 16` in some jobs (also EOL)
- These are larger changes that should be handled separately to keep this PR low-risk

## Test Plan

- [ ] Verify no `@v2` or `@v3` action references remain in workflow files
- [ ] Confirm downstream projects consuming these workflows pass CI

Made with [Cursor](https://cursor.com)